### PR TITLE
Navigation: Put ViewAligner after ViewManager

### DIFF
--- a/docs/pages/FamilyReviser/FR-FamilyReviser-user-guide.md
+++ b/docs/pages/FamilyReviser/FR-FamilyReviser-user-guide.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: FamilyReviser User Guide
-nav_order: 9
+nav_order: 10
 has_children: true
 permalink: /docs/familyreviser-user-guide
 ---

--- a/docs/pages/OneFilter/OF-OneFilter-user-guide.md
+++ b/docs/pages/OneFilter/OF-OneFilter-user-guide.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: OneFilter User Guide
-nav_order: 11
+nav_order: 12
 has_children: true
 permalink: /docs/onefilter-user-guide
 ---

--- a/docs/pages/ParaManager/PM-ParaManager-user-guide.md
+++ b/docs/pages/ParaManager/PM-ParaManager-user-guide.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: ParaManager User Guide
-nav_order: 10
+nav_order: 11
 has_children: true
 permalink: /docs/paramanager-user-guide
 ---

--- a/docs/pages/PointKit/PK-PointKit-user-guide.md
+++ b/docs/pages/PointKit/PK-PointKit-user-guide.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: PointKit User Guide
-nav_order: 13
+nav_order: 14
 has_children: true
 permalink: /docs/pointkit-user-guide
 ---

--- a/docs/pages/QuickViews/QV-QuickViews-user-guide.md
+++ b/docs/pages/QuickViews/QV-QuickViews-user-guide.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: QuickViews User Guide
-nav_order: 8
+nav_order: 9
 has_children: true
 permalink: /docs/QuickViews-user-guide
 ---

--- a/docs/pages/ReOrdering/RO-ReOrdering-user-guide.md
+++ b/docs/pages/ReOrdering/RO-ReOrdering-user-guide.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: ReOrdering User Guide
-nav_order: 12
+nav_order: 13
 has_children: true
 permalink: /docs/reordering-user-guide
 ---

--- a/docs/pages/SectionBoxer/SB-SectionBoxer-user-guide.md
+++ b/docs/pages/SectionBoxer/SB-SectionBoxer-user-guide.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: SectionBoxer User Guide
-nav_order: 14
+nav_order: 15
 has_children: true
 permalink: /docs/SectionBoxer-user-guide
 ---

--- a/docs/pages/ViewAligner/VA-ViewAligner-user-guide.md
+++ b/docs/pages/ViewAligner/VA-ViewAligner-user-guide.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: ViewAligner User Guide
-nav_order: 15
+nav_order: 8
 has_children: true
 permalink: /docs/ViewAligner-user-guide
 ---


### PR DESCRIPTION
This pull request updates the navigation order for several user guide documentation pages to adjust their sequence in the documentation sidebar. No content changes were made to the guides themselves—only the `nav_order` values were modified to reorganize their display order.

Documentation navigation reordering:

* Changed `nav_order` for `ViewAligner` user guide from 15 to 8.
* Changed `nav_order` for `QuickViews` user guide from 8 to 9.
* Changed `nav_order` for `FamilyReviser` user guide from 9 to 10.
* Changed `nav_order` for `ParaManager` user guide from 10 to 11.
* Changed `nav_order` for `OneFilter` user guide from 11 to 12.
* Changed `nav_order` for `ReOrdering` user guide from 12 to 13.
* Changed `nav_order` for `PointKit` user guide from 13 to 14.
* Changed `nav_order` for `SectionBoxer` user guide from 14 to 15.